### PR TITLE
Add rel="noreferrer noopener" to target="_blank" links by default.

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -233,6 +233,7 @@ export default class Editor {
         $(anchor).attr('href', linkUrl);
         if (isNewWindow) {
           $(anchor).attr('target', '_blank');
+          $(anchor).attr('rel', 'noreferrer noopener');
         } else {
           $(anchor).removeAttr('target');
         }


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- `createLink` add rel="noreferrer noopener" to target="_blank" links.

It is helpless if a malicious user edits from the editor, but why not add the attribute by default?

#### Where should the reviewer start?

- Make sure that the `rel="noreferrer noopener"` attribute is given when you generate a link that opens in a new window.

#### How should this be manually tested?

- generate a link that opens in a new window.

#### Any background context you want to provide?

- https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html#tabnabbing
  > For HTML links, add the attribute rel="noopener noreferrer" to every link.

#### What are the relevant tickets?


#### Screenshot (if for frontend)

https://user-images.githubusercontent.com/38872854/117273361-090be000-ae97-11eb-8114-b05202340786.mov

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
